### PR TITLE
feat: add PowerShell script to export installed Windows apps to CSV (#8)

### DIFF
--- a/app-exporter/README.md
+++ b/app-exporter/README.md
@@ -1,0 +1,24 @@
+# 📦 App Exporter
+
+A PowerShell script to list all installed applications on a Windows system and export them to a CSV file. Supports optional filters by publisher and estimated size.
+
+# 🚀 Usage
+
+```powershell
+# Basic usage
+.\export-apps.ps1
+```
+
+## Filter by publisher
+```
+.\export-apps.ps1 -Publisher "Microsoft"
+```
+
+## Filter by minimum size
+```
+.\export-apps.ps1 -MinSizeMB 100
+```
+## Save to a custom path
+```
+.\export-apps.ps1 -OutputPath "C:\apps.csv"
+```

--- a/app-exporter/export-apps.ps1
+++ b/app-exporter/export-apps.ps1
@@ -1,0 +1,59 @@
+[CmdletBinding()]
+param (
+    [string]$Publisher,
+    [int]$MinSizeMB,
+    [string]$OutputPath = "installed_apps.csv"
+)
+
+function Get-InstalledApps {
+    $registryPaths = @(
+        "HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*",
+        "HKLM:\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*"
+    )
+
+    $apps = @()
+
+    foreach ($path in $registryPaths) {
+        $items = Get-ItemProperty -Path $path -ErrorAction SilentlyContinue
+
+        foreach ($item in $items) {
+            if (-not $item.DisplayName) { continue }
+
+            $app = [PSCustomObject]@{
+                Name        = $item.DisplayName
+                Version     = $item.DisplayVersion
+                InstallDate = $item.InstallDate
+                Publisher   = $item.Publisher
+                SizeMB      = if ($item.EstimatedSize) { [math]::Round($item.EstimatedSize / 1024, 2) } else { "N/A" }
+            }
+
+            $apps += $app
+        }
+    }
+
+    return $apps
+}
+
+# Run scan
+Write-Host "Scanning installed applications..." -ForegroundColor Cyan
+$apps = Get-InstalledApps
+
+# Filter by Publisher
+if ($Publisher) {
+    Write-Host "Filtering by Publisher: $Publisher" -ForegroundColor Yellow
+    $apps = $apps | Where-Object { $_.Publisher -match [regex]::Escape($Publisher) }
+}
+
+# Filter by Size
+if ($MinSizeMB) {
+    Write-Host "Filtering by Minimum Size: $MinSizeMB MB" -ForegroundColor Yellow
+    $apps = $apps | Where-Object {
+        ($_."SizeMB" -ne "N/A") -and ($_."SizeMB" -ge $MinSizeMB)
+    }
+}
+
+# Export
+Write-Host "Exporting results to: $OutputPath" -ForegroundColor Green
+$apps | Export-Csv -Path $OutputPath -NoTypeInformation -Encoding UTF8
+
+Write-Host "Done. Exported $($apps.Count) app(s)." -ForegroundColor Green


### PR DESCRIPTION
## 📦 What This Does

- Adds a new PowerShell script: `app-exporter/export-apps.ps1`
- Lists all installed Windows applications using registry keys
- Extracts key fields:  
  - Name  
  - Version  
  - InstallDate  
  - Publisher  
  - EstimatedSize (MB)
- Supports optional filters:
  - `-Publisher` (partial, case-insensitive)
  - `-MinSizeMB` (integer filter)
- Outputs results to a CSV file using `Export-Csv`

## 🧪 Usage Examples

```powershell
# Export everything
.\export-apps.ps1

# Filter by publisher
.\export-apps.ps1 -Publisher "Microsoft"

# Filter by minimum size
.\export-apps.ps1 -MinSizeMB 100

# Custom output path
.\export-apps.ps1 -OutputPath "C:\Users\me\Desktop\apps.csv"
```


Closes #8 