### PR TITLE
Add interactive PowerShell script to toggle Defender real-time protection (#9)

### DIFF
--- a/defender-toggle/Readme.md
+++ b/defender-toggle/Readme.md
@@ -1,0 +1,32 @@
+# 🛡️ Defender Real-Time Protection Toggle Script
+
+A PowerShell script to **enable or disable Windows Defender Real-Time Protection** interactively.  
+Useful for automation, testing, or temporary performance boosts—**but use with care!**
+
+---
+
+## 🚨 IMPORTANT: READ THIS FIRST
+
+- **Tamper Protection:**  
+  Windows 10/11's Tamper Protection **must be disabled** for this script to work.  
+  (You **cannot** turn off Tamper Protection via script—must be done manually.)
+- **Administrator:**  
+  The script must be run in an **elevated PowerShell window** (Run as Administrator).
+- **Responsibility:**  
+  Disabling Defender exposes you to malware/ransomware—**turn it back ON** after your work!
+- **Exclusions Alternative:**  
+  For most automation, simply **exclude your test folders** instead of disabling Defender entirely:
+  ```powershell
+  Add-MpPreference -ExclusionPath "C:\your\test\folder"
+  ```
+
+## 📄 What This Script Does
+
+- Shows Defender’s current Real-Time Protection status.
+- Prompts you to turn protection ON or OFF (or quit).
+- Applies your choice.
+- Confirms the new status.
+- Checks both the preference flag and actual service state for maximum clarity.
+
+---
+

--- a/defender-toggle/defender-toggle.ps1
+++ b/defender-toggle/defender-toggle.ps1
@@ -1,0 +1,81 @@
+<#
+.SYNOPSIS
+  Interactive script to enable/disable Windows Defender Real-Time Protection.
+
+.DESCRIPTION
+  - Shows current status
+  - Asks user for ON/OFF choice
+  - Applies the change
+  - Confirms after
+
+.NOTES
+  Must run as Administrator, and Tamper Protection must be OFF.
+#>
+
+# Admin check
+if (-not ([Security.Principal.WindowsPrincipal] `
+    [Security.Principal.WindowsIdentity]::GetCurrent() `
+).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Error "❌ Please run this script as Administrator."
+    exit 1
+}
+
+# Ensure Defender module is loaded (built-in on Win10/11)
+Import-Module Defender -ErrorAction SilentlyContinue
+
+# Fetch current status
+$currentPref = (Get-MpPreference).DisableRealtimeMonitoring
+$currentSvc  = (Get-MpComputerStatus).RealTimeProtectionEnabled
+
+Write-Host ""
+Write-Host "=== Defender Real-Time Protection Status ==="
+Write-Host ("  • DisableRealtimeMonitoring: {0}" -f $currentPref)
+Write-Host ("  • RealTimeProtectionEnabled: {0}" -f $currentSvc)
+Write-Host ""
+
+# Ask user what to do
+$action = Read-Host "Type 'OFF' to disable, 'ON' to enable, or 'Q' to quit"
+
+switch ($action.ToUpper()) {
+    'OFF' {
+        if ($currentSvc -eq $false) {
+            Write-Host "Already OFF. No action taken."
+        } else {
+            Set-MpPreference -DisableRealtimeMonitoring $true
+            Write-Host "Attempted to DISABLE real-time protection."
+        }
+    }
+    'ON' {
+        if ($currentSvc -eq $true) {
+            Write-Host "Already ON. No action taken."
+        } else {
+            Set-MpPreference -DisableRealtimeMonitoring $false
+            Write-Host "Attempted to ENABLE real-time protection."
+        }
+    }
+    'Q' {
+        Write-Host "Quitting. No changes made."
+        exit 0
+    }
+    Default {
+        Write-Warning "Invalid input. Please type ON, OFF, or Q."
+        exit 1
+    }
+}
+
+# Confirm result
+$afterPref = (Get-MpPreference).DisableRealtimeMonitoring
+$afterSvc  = (Get-MpComputerStatus).RealTimeProtectionEnabled
+
+Write-Host ""
+Write-Host "=== Status After Change ==="
+Write-Host ("  • DisableRealtimeMonitoring: {0}" -f $afterPref)
+Write-Host ("  • RealTimeProtectionEnabled: {0}" -f $afterSvc)
+
+if ($afterSvc -eq $false) {
+    Write-Host "✅ Real-Time Protection is DISABLED."
+} elseif ($afterSvc -eq $true) {
+    Write-Host "✅ Real-Time Protection is ENABLED."
+} else {
+    Write-Host "⚠️ Status unknown."
+}


### PR DESCRIPTION
## What’s new?

- Adds an interactive PowerShell script under `defender-toggle/` to enable or disable Windows Defender Real-Time Protection
- Prompts user to enable, disable, or quit
- Displays Defender status before and after user action
- Checks both the Defender preference flag and actual engine status for accuracy

## Why?

- Helps automation, testing, and performance scenarios that require toggling Defender on/off
- Avoids manual clicking and streamlines developer workflow

## Requirements & Warnings

- Must be run as Administrator
- Tamper Protection must be **disabled** in Windows Security for this script to work (this cannot be bypassed programmatically)
- Script should be used responsibly—re-enable Defender when done!

## Testing

- Script tested on Windows 11, PowerShell 5.1+
- If Tamper Protection is ON, script detects and instructs user to turn it off

---

Closes #9 
